### PR TITLE
Fix logging Rack query string

### DIFF
--- a/lib/dry/monitor/rack/logger.rb
+++ b/lib/dry/monitor/rack/logger.rb
@@ -12,7 +12,7 @@ module Dry
         PATH_INFO = 'PATH_INFO'.freeze
         REMOTE_ADDR = 'REMOTE_ADDR'.freeze
         RACK_INPUT = 'rack.input'.freeze
-        QUERY_PARAMS = 'QUERY_PARAMS'.freeze
+        QUERY_STRING = 'QUERY_STRING'.freeze
 
         START_MSG = %(Started %s "%s" for %s at %s).freeze
         STOP_MSG = %(Finished %s "%s" for %s in %sms [Status: %s]\n).freeze
@@ -69,7 +69,7 @@ module Dry
         end
 
         def log_request_params(request)
-          with_http_params(request[QUERY_PARAMS]) do |params|
+          with_http_params(request[QUERY_STRING]) do |params|
             info QUERY_MSG % [params.inspect]
           end
         end

--- a/spec/integration/rack_middleware_spec.rb
+++ b/spec/integration/rack_middleware_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Dry::Monitor::Rack::Middleware do
 
   describe '#call' do
     let(:env) do
-      { 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/hello-world', 'REMOTE_ADDR' => '0.0.0.0', 'QUERY_PARAMS' => query_params }
+      { 'REQUEST_METHOD' => 'GET', 'PATH_INFO' => '/hello-world', 'REMOTE_ADDR' => '0.0.0.0', 'QUERY_STRING' => query_params }
     end
 
     let(:query_params) do


### PR DESCRIPTION
Hi, team!

I just caught a small bug: monitor Rack logger doesn't log query params in Rack applications (based on dry-web-roda for instance), because Rack specification [uses](http://www.rubydoc.info/github/rack/rack/master/file/SPEC) `QUERY_STRING` key for store query params in the ENV, but not `QUERY_PARAMS`.