### PR TITLE
Fix rack params filtering when query params contain arrays of primitives

### DIFF
--- a/lib/dry/monitor/rack/logger.rb
+++ b/lib/dry/monitor/rack/logger.rb
@@ -91,12 +91,12 @@ module Dry
 
         def filter_params(params)
           params.each_with_object({}) do |(k, v), h|
-            if v.is_a?(Hash)
+            if config.filtered_params.include?(k)
+              h.update(k => FILTERED)
+            elsif v.is_a?(Hash)
               h.update(k => filter_params(v))
             elsif v.is_a?(Array)
-              h.update(k => v.map { |m| filter_params(m) })
-            elsif config.filtered_params.include?(k)
-              h.update(k => FILTERED)
+              h.update(k => v.map { |m| m.is_a?(Hash) ? filter_params(m) : m })
             else
               h[k] = v
             end

--- a/spec/integration/instrumentation_spec.rb
+++ b/spec/integration/instrumentation_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe 'Subscribing to instrumentation events' do
   subject(:notifications) { Dry::Monitor::Notifications.new(:app) }
 

--- a/spec/integration/logger_spec.rb
+++ b/spec/integration/logger_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Dry::Monitor::Logger do
   subject(:logger) do
     Dry::Monitor::Logger.new($stdout)

--- a/spec/integration/rack_middleware_spec.rb
+++ b/spec/integration/rack_middleware_spec.rb
@@ -25,7 +25,17 @@ RSpec.describe Dry::Monitor::Rack::Middleware do
     end
 
     let(:query_params) do
-      '_csrf=123456&password=secret&user[password]=secret&other[][password]=secret&other[][password]=secret&foo=bar&one=1'
+      %w[
+        _csrf=123456
+        password=secret
+        user[password]=secret
+        others[][password]=secret1
+        others[][password]=secret2
+        foo=bar
+        one=1
+        ids[]=1
+        ids[]=2
+      ].join('&')
     end
 
     before do
@@ -45,7 +55,7 @@ RSpec.describe Dry::Monitor::Rack::Middleware do
 
       expect(log_file_content).to include('Started GET "/hello-world"')
       expect(log_file_content).to include('Finished GET "/hello-world"')
-      expect(log_file_content).to include('Query parameters {"_csrf"=>"[FILTERED]", "password"=>"[FILTERED]", "user"=>{"password"=>"[FILTERED]"}, "other"=>[{"password"=>"[FILTERED]"}, {"password"=>"[FILTERED]"}], "foo"=>"bar", "one"=>"1"}')
+      expect(log_file_content).to include('Query parameters {"_csrf"=>"[FILTERED]", "password"=>"[FILTERED]", "user"=>{"password"=>"[FILTERED]"}, "others"=>[{"password"=>"[FILTERED]"}, {"password"=>"[FILTERED]"}], "foo"=>"bar", "one"=>"1", "ids"=>["1", "2"]}')
     end
   end
 

--- a/spec/integration/rack_middleware_spec.rb
+++ b/spec/integration/rack_middleware_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Dry::Monitor::Rack::Middleware do
   subject(:middleware) { Dry::Monitor::Rack::Middleware.new(notifications).new(rack_app) }
 

--- a/spec/integration/sql_logger_spec.rb
+++ b/spec/integration/sql_logger_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 RSpec.describe Dry::Monitor::SQL::Logger do
   subject(:logger) { sql_logger.new(Dry::Monitor::Logger.new(log_file_path)) }
 


### PR DESCRIPTION
This stops the rack logger from crashing when handling a request containing a query string like `?ids[]=1&ids[]=2` (i.e. `{"ids" => ["1", "2"]}`).

I've also rearranged the logic in the param filtering so that matching keys are filtered first thing, which'd allow for entire objects/hashes to be filtered out, which wasn't possible before.