### PR TITLE
Performance and memory optimization

### DIFF
--- a/lib/dry/monitor/notifications.rb
+++ b/lib/dry/monitor/notifications.rb
@@ -1,7 +1,5 @@
 require 'dry/events/publisher'
 
-GC.disable
-
 module Dry
   module Monitor
     class Clock

--- a/lib/dry/monitor/notifications.rb
+++ b/lib/dry/monitor/notifications.rb
@@ -37,10 +37,12 @@ module Dry
           result, time = @clock.measure { yield }
         end
 
-        payload[:time] = time if time
-
         process(event_id, payload) do |event, listener|
-          time ? listener.(event.payload(payload)) : listener.(event)
+          if time
+            listener.(event.payload(payload.merge(time: time)))
+          else
+            listener.(event)
+          end
         end
 
         result


### PR DESCRIPTION
Good afternoon,

During my work on Karafka new instrumentation engine (https://github.com/karafka/karafka/compare/monitor) I took a bit of time to improve the performance of dry-monitor.

Karafka is designed to process a lot of data, so anything that slows it down will have a big impact on it.

How did I benchmark?

Lazy ;)

```ruby
100.times do
  t = Time.now.to_f
  100_000.times do
    notifications.instrument(:name, {}) do
    end
  end
  p Time.now.to_f - t
end
```

GC was enabled, as there is an impact on merging in place instead of replacing the hash and it has impact as well. Other than that I've moved some parts to save on method calls and yielded instead of blocks.

Here are the results:

| After               | Before              |
| ------------------- |---------------------|
| 0.23590040206909180 | 0.25153875350952150 |
| 0.23336219787597656 | 0.25589752197265625 |
| 0.23708105087280273 | 0.26225399971008300 |
| 0.23918604850769043 | 0.25381994247436523 |
| 0.23202466964721680 | 0.25196862220764160 |
| 0.22906446456909180 | 0.25158977508544920 |
| 0.23311257362365723 | 0.25442576408386230 |
| 0.22904443740844727 | 0.25594353675842285 |
| 0.22365212440490723 | 0.25676465034484863 |
| 0.22846508026123047 | 0.25955748558044434 |
| 0.22670793533325195 | 0.26439571380615234 |
| 0.24390196800231934 | 0.25290441513061523 |
| 0.23434638977050780 | 0.25111293792724610 |
| 0.23367738723754883 | 0.25260972976684570 |
| 0.22855281829833984 | 0.26616740226745605 |
| 0.22979569435119630 | 0.25122141838073730 |

| After sum           | Before sum          |
| ------------------- |---------------------|
| 3,717875242         | 4,092171669         |


Diff: 10,06748216%
