### PR TITLE
rack not found fix, sql and rack as optional deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.3.0 2018-01-29
+
+### Fixed
+
+* cannot load such file -- rack/utils (mensfeld)
+
+### Changed
+
+* Make `rack` logger into a plugin (mensfeld)
+* Make `sql` logger into a plugin (mensfeld)
+
 # v0.2.0 2018-01-21
 
 ### Changed

--- a/lib/dry/monitor.rb
+++ b/lib/dry/monitor.rb
@@ -2,4 +2,14 @@ require 'dry/monitor/logger'
 require 'dry/monitor/notifications'
 require 'dry/monitor/rack/middleware'
 require 'dry/monitor/rack/logger'
-require 'dry/monitor/sql/logger'
+require 'dry/core/extensions'
+
+module Dry
+  module Monitor
+    extend Dry::Core::Extensions
+
+    register_extension(:sql) do
+      require 'dry/monitor/sql/logger'
+    end
+  end
+end

--- a/lib/dry/monitor.rb
+++ b/lib/dry/monitor.rb
@@ -1,12 +1,15 @@
 require 'dry/monitor/logger'
 require 'dry/monitor/notifications'
-require 'dry/monitor/rack/middleware'
-require 'dry/monitor/rack/logger'
 require 'dry/core/extensions'
 
 module Dry
   module Monitor
     extend Dry::Core::Extensions
+
+    register_extension(:rack) do
+      require 'rack/utils'
+      require 'dry/monitor/rack/logger'
+    end
 
     register_extension(:sql) do
       require 'dry/monitor/sql/logger'

--- a/lib/dry/monitor/rack/logger.rb
+++ b/lib/dry/monitor/rack/logger.rb
@@ -1,4 +1,5 @@
 require 'dry/configurable'
+require 'dry/monitor/rack/middleware'
 
 module Dry
   module Monitor

--- a/lib/dry/monitor/rack/middleware.rb
+++ b/lib/dry/monitor/rack/middleware.rb
@@ -1,4 +1,3 @@
-require 'rack/utils'
 require 'dry/monitor/notifications'
 
 module Dry

--- a/lib/dry/monitor/version.rb
+++ b/lib/dry/monitor/version.rb
@@ -1,5 +1,5 @@
 module Dry
   module Monitor
-    VERSION = '0.2.0'.freeze
+    VERSION = '0.3.0'.freeze
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ begin
 rescue LoadError; end
 
 require 'dry-monitor'
-Dry::Monitor.load_extensions(:sql)
+Dry::Monitor.load_extensions(:sql, :rack)
 
 SPEC_ROOT = Pathname(__dir__)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ begin
 rescue LoadError; end
 
 require 'dry-monitor'
+Dry::Monitor.load_extensions(:sql)
 
 SPEC_ROOT = Pathname(__dir__)
 


### PR DESCRIPTION
close https://github.com/dry-rb/dry-monitor/issues/16

Also moves both `sql` and `rack` into plugins that don't need to be loaded at all.