### PR TITLE
CI: Use 2.6.2, 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 bundler_args: --without benchmarks tools
 before_install: gem update --system
 before_script:
@@ -12,8 +11,8 @@ after_script:
 script:
   - bundle exec rake ci
 rvm:
-  - 2.6.1
-  - 2.5.3
+  - 2.6.2
+  - 2.5.5
   - 2.4.5
   - 2.3.8
   - jruby-9.2.6.0


### PR DESCRIPTION
This PR updates the CI matrix.

  - Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration