### PR TITLE
fix uninitialized constant Dry::Monitor::Notifications::EMPTY_HASH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+### Fixed
+
+* uninitialized constant Dry::Monitor::Notifications::EMPTY_HASH when no payload given (mensfeld)
+
 # v0.3.0 2019-01-29
 
 ### Fixed

--- a/lib/dry/monitor/notifications.rb
+++ b/lib/dry/monitor/notifications.rb
@@ -1,4 +1,5 @@
 require 'dry/events/publisher'
+require 'dry/core/constants'
 
 module Dry
   module Monitor
@@ -18,12 +19,11 @@ module Dry
 
     class Notifications
       include Events::Publisher['Dry::Monitor::Notifications']
+      include Dry::Core::Constants
 
       attr_reader :id
 
       attr_reader :clock
-
-      EMPTY_HASH = {}.freeze
 
       def initialize(id)
         @id = id

--- a/lib/dry/monitor/notifications.rb
+++ b/lib/dry/monitor/notifications.rb
@@ -23,6 +23,8 @@ module Dry
 
       attr_reader :clock
 
+      EMPTY_HASH = {}.freeze
+
       def initialize(id)
         @id = id
         @clock = CLOCK

--- a/spec/integration/instrumentation_spec.rb
+++ b/spec/integration/instrumentation_spec.rb
@@ -33,5 +33,17 @@ RSpec.describe 'Subscribing to instrumentation events' do
 
       expect(captured).to eql([[:sql, 'SELECT 1 FROM users']])
     end
+
+    it 'allows instrumenting via block when no payload given' do
+      captured = []
+
+      notifications.subscribe(:sql) do |event|
+        captured << [event.id]
+      end
+
+      notifications.instrument(:sql) {}
+
+      expect(captured).to eql([[:sql]])
+    end
   end
 end


### PR DESCRIPTION
close https://github.com/dry-rb/dry-monitor/issues/27