### PR TITLE
Avoid slow RubyGems update and re-enable TruffleRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 bundler_args: --without benchmarks tools
-before_install: gem update --system
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ rvm:
   - 2.5.5
   - 2.4.6
   - jruby-9.2.7.0
+  - truffleruby
 env:
   global:
     - COVERAGE=true


### PR DESCRIPTION
From the discussion on https://twitter.com/eregontp/status/1141272669297532928