### PR TITLE
Fix dry-event version in runtime dependencies

### DIFF
--- a/dry-monitor.gemspec
+++ b/dry-monitor.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dry-configurable", "~> 0.5"
   spec.add_runtime_dependency "dry-core", "~> 0.4"
   spec.add_runtime_dependency "dry-equalizer", "~> 0.2"
-  spec.add_runtime_dependency "dry-events", "~> 0.5"
+  spec.add_runtime_dependency "dry-events", "~> 0.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Latest dry-event release - `0.2.0` ([source](https://github.com/dry-rb/dry-events/releases)). But we have `0.5.0` in gemspec file.

Related to https://github.com/dry-rb/dry-monitor/pull/34