### PR TITLE
Ensure `Dry::Monitor::Rack::Middleware#new` to be compatible with `Rack::Builder#use`

### DIFF
--- a/lib/dry/monitor/rack/middleware.rb
+++ b/lib/dry/monitor/rack/middleware.rb
@@ -22,7 +22,7 @@ module Dry
           @notifications, @app = *args
         end
 
-        def new(app)
+        def new(app, *_args, &_block)
           self.class.new(notifications, app)
         end
 


### PR DESCRIPTION
`Rack::Builder#use` can potentially pass three arguments to a middleware: `app`, `*args`, and a `&block`.

`Dry::Monitor::Rack::Middleware#new` should support this syntax for full compatibility with Rack ecosystem.

This is a blocker for https://github.com/hanami/hanami/pull/1032 See my comment there https://github.com/hanami/hanami/pull/1032/files#r402784952