### PR TITLE
Don't create a new formatter object on each Monitor::Logger.new call

### DIFF
--- a/lib/dry/monitor/logger.rb
+++ b/lib/dry/monitor/logger.rb
@@ -5,11 +5,13 @@ require 'logger'
 module Dry
   module Monitor
     class Logger < ::Logger
+      DEFAULT_FORMATTER = proc do |_severity, _datetime, _progname, msg|
+        "#{msg}\n"
+      end
+
       def initialize(*args)
         super
-        self.formatter = proc do |_severity, _datetime, _progname, msg|
-          "#{msg}\n"
-        end
+        self.formatter = DEFAULT_FORMATTER
       end
     end
   end


### PR DESCRIPTION
Hey,

I found a one more place which we can improve. We create a new `proc` object each time when we call `Dry::Monitor::Logger.new` and we need this object for simple logger formatter. I just memoize this object to constant and now we don't allocate it everytime.

## Results
I used [memory_profiler](https://github.com/SamSaffron/memory_profiler) for experiment: 
```ruby
report = MemoryProfiler.report do
  100.times do
    Dry::Monitor.load_extensions(:sql, :rack)
  end
end
```


### Before
```
Total allocated: 1395236 bytes (20215 objects)
Total retained:  368 bytes (2 objects)

allocated memory by gem
-----------------------------------
    672936  rack-2.0.4
    506820  dry-monitor/lib
    144000  uri
     41600  dry-events/lib
     25800  logger
      4000  other
        80  dry-configurable-0.11.5
```

### After
```
Total allocated: 968733 bytes (10294 objects)
Total retained:  195349 bytes (1497 objects)

allocated memory by gem
-----------------------------------
    350539  rack-2.0.4
    195009  dry-configurable-0.11.5
    153421  dry-monitor/lib
     77472  fileutils
     63079  tempfile
     47936  delegate
     36148  x86_64-darwin19
     15524  time
     13274  concurrent-ruby-1.1.6
      5111  dry-equalizer-0.3.0
      4000  other
      3672  set
      1664  tmpdir
      1220  date
       464  dry-core-0.4.9
       200  dry-events/lib
```