### PR TITLE
Always expect an event to be passed to subscribers.

### DIFF
--- a/lib/dry/monitor/rack/logger.rb
+++ b/lib/dry/monitor/rack/logger.rb
@@ -31,12 +31,12 @@ module Dry
         end
 
         def attach(rack_monitor)
-          rack_monitor.on(:start) do |env:|
-            log_start_request(env)
+          rack_monitor.on(:start) do |event|
+            log_start_request(event[:env])
           end
 
-          rack_monitor.on(:stop) do |env:, status:, time:|
-            log_stop_request(env, status, time)
+          rack_monitor.on(:stop) do |event|
+            log_stop_request(event[:env], event[:status], event[:time])
           end
 
           rack_monitor.on(:error) do |event|

--- a/lib/dry/monitor/sql/logger.rb
+++ b/lib/dry/monitor/sql/logger.rb
@@ -53,8 +53,8 @@ module Dry
         end
 
         def subscribe(notifications)
-          notifications.subscribe(:sql) do |time:, name:, query:|
-            log_query(time, name, query)
+          notifications.subscribe(:sql) do |event|
+            log_query(event[:time], event[:name], event[:query])
           end
         end
 


### PR DESCRIPTION
From what I can understand, the previous behaviour passed the event through - but, because of `Dry::Events::Event#[]`, it could be implicitly converted into keyword arguments.

With Ruby 3 no longer making implicit conversions of keyword arguments, I don't see this old behaviour as feasible - instead, the built-in subscribers should instead expect the event object, and get the particular keyed values out from it.

I'm not sure how significant a change this is, but I can foresee it breaking usage for others if they're using keyword arguments in their subscribers. I also note that there's been detailed discussions around payloads in #32 - perhaps this PR is moot depending on how that plays out? 🤷🏻‍♂️