### PR TITLE
Extend Clock with support for configurable units

### DIFF
--- a/lib/dry/monitor/clock.rb
+++ b/lib/dry/monitor/clock.rb
@@ -4,6 +4,11 @@ module Dry
   module Monitor
     # @api public
     class Clock
+      # @api private
+      def initialize(unit: :millisecond)
+        @unit = unit
+      end
+
       # @api public
       def measure
         start = current
@@ -13,7 +18,7 @@ module Dry
 
       # @api public
       def current
-        Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+        Process.clock_gettime(Process::CLOCK_MONOTONIC, @unit)
       end
     end
   end

--- a/lib/dry/monitor/notifications.rb
+++ b/lib/dry/monitor/notifications.rb
@@ -12,9 +12,9 @@ module Dry
 
       attr_reader :id, :clock
 
-      def initialize(id)
+      def initialize(id, clock: CLOCK)
         @id = id
-        @clock = CLOCK
+        @clock = clock
       end
 
       def start(event_id, payload)

--- a/lib/dry/monitor/rack/logger.rb
+++ b/lib/dry/monitor/rack/logger.rb
@@ -16,7 +16,7 @@ module Dry
         QUERY_STRING = "QUERY_STRING"
 
         START_MSG = %(Started %s "%s" for %s at %s)
-        STOP_MSG = %(Finished %s "%s" for %s in %sms [Status: %s]\n)
+        STOP_MSG = %(Finished %s "%s" for %s in %s [Status: %s]\n)
         QUERY_MSG = %(  Query parameters )
         FILTERED = "[FILTERED]"
 

--- a/lib/dry/monitor/rack/middleware.rb
+++ b/lib/dry/monitor/rack/middleware.rb
@@ -14,12 +14,13 @@ module Dry
 
         attr_reader :app, :notifications
 
-        def initialize(*args)
+        def initialize(*args, clock: CLOCK)
           @notifications, @app = *args
+          @clock = clock
         end
 
-        def new(app, *_args, &_block)
-          self.class.new(notifications, app)
+        def new(app, *_args, clock: @clock, &_block)
+          self.class.new(notifications, app, clock: clock)
         end
 
         def on(event_id, &block)
@@ -32,7 +33,7 @@ module Dry
 
         def call(env)
           notifications.start(REQUEST_START, env: env)
-          response, time = CLOCK.measure { app.call(env) }
+          response, time = @clock.measure { app.call(env) }
           notifications.stop(REQUEST_STOP, env: env, time: time, status: response[0])
           response
         end

--- a/spec/integration/rack_middleware_spec.rb
+++ b/spec/integration/rack_middleware_spec.rb
@@ -3,10 +3,16 @@
 require "rack/builder"
 
 RSpec.describe Dry::Monitor::Rack::Middleware do
-  subject(:middleware) { Dry::Monitor::Rack::Middleware.new(notifications).new(rack_app) }
+  subject(:middleware) do
+    Dry::Monitor::Rack::Middleware.new(notifications).new(rack_app, clock: clock)
+  end
 
   let(:notifications) do
-    Dry::Monitor::Notifications.new(:test)
+    Dry::Monitor::Notifications.new(:test, clock: clock)
+  end
+
+  let(:clock) do
+    Dry::Monitor::Clock.new(unit: :microsecond)
   end
 
   let(:rack_app) do
@@ -44,7 +50,7 @@ RSpec.describe Dry::Monitor::Rack::Middleware do
 
   describe "#new" do
     let(:builder) do
-      middleware = described_class.new(notifications)
+      middleware = described_class.new(notifications, clock: clock)
       inner = rack_app
 
       Rack::Builder.new do


### PR DESCRIPTION
This was long time coming and now just before Hanami 2.0 we really need to ship this feature as Hanami can go below 1ms with response times.

The built-in rack logger here should be already deprecated btw. I totally forgot about this prior releasing 1.0.0 🤦🏻 